### PR TITLE
Python 3+ support and MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 European Synchrotron Radiation Facility
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pygix/grazing_units.py
+++ b/pygix/grazing_units.py
@@ -149,7 +149,7 @@ GI_UNITS = (TTH_DEG, TTH_RAD, Q_NM, Q_A)
 
 def to_unit(obj):
     giUnit = None
-    if type(obj) in types.StringTypes:
+    if isinstance(obj, str):
         for one_unit in GI_UNITS:
             if one_unit.REPR == obj:
                 giUnit = one_unit
@@ -221,7 +221,7 @@ def op_unit(obj):
 
 def absolute_unit(obj):
     abs_giUnit = None
-    print type(obj)
+    print(type(obj))
     if type(obj) in types.StringTypes:
         for one_unit in ABS_UNITS:
             if one_unit.REPR == obj:
@@ -233,6 +233,6 @@ def absolute_unit(obj):
         logger.error("Unable to recognize this type unit '%s' of type %s. "
                      "Valid units are 2th_deg, 2th_rad, q_nm^-1, q_A^-1 and r_mm"\
                      % (obj, type(obj)))
-    print abs_giUnit
+    print(abs_giUnit)
     return abs_giUnit        
 

--- a/pygix/io.py
+++ b/pygix/io.py
@@ -212,7 +212,7 @@ class Writer(object):
                                 header={"EDF_DataBlockID": "1.Image.Error"})
             img.write(filename)
         except IOError:
-            print "IOError while writing %s" % filename
+            print("IOError while writing %s" % filename)
 
 
 def make_roi_header(**param):

--- a/pygix/process.py
+++ b/pygix/process.py
@@ -153,7 +153,7 @@ class Processor(object):
         t_start = time.time()
 
         for i, f in enumerate(file_list):
-            print 'processing file: {}/{}\n\t{}'.format(i + 1, n_files, f)
+            print('processing file: {}/{}\n\t{}'.format(i + 1, n_files, f))
 
             # THIS WORKS BUT NEEDS TESTING
             # if self.out_fname is not None:
@@ -166,7 +166,7 @@ class Processor(object):
         t_end = time.time() - t_start
         msg = '{} files processed in {} seconds\n'
         msg += '{} seconds per file'
-        print msg.format(n_files, t_end, t_end/n_files)
+        print(msg.format(n_files, t_end, t_end/n_files))
 
         y_scale = np.arange(0, n_files)
         out = (out_array, x_scale, y_scale)
@@ -185,7 +185,7 @@ class Processor(object):
         t_start = time.time()
 
         for i, f in enumerate(file_list):
-            print 'processing file: {}/{}\n\t{}'.format(i + 1, n_files, f)
+            print('processing file: {}/{}\n\t{}'.format(i + 1, n_files, f))
 
             # THIS WORKS BUT NEEDS TESTING
             # if self.out_fname is not None:
@@ -197,7 +197,7 @@ class Processor(object):
         t_end = time.time() - t_start
         msg = '{} files processed in {} seconds\n'
         msg += '{} seconds per file'
-        print msg.format(n_files, t_end, t_end/n_files)
+        print(msg.format(n_files, t_end, t_end/n_files))
 
         return True
 
@@ -369,7 +369,7 @@ def init_pygix(calibration_dict):
 
 if __name__ == '__main__':
     if len(sys.argv) is not 2:
-        print 'usage: process.py recipe.yaml'
+        print('usage: process.py recipe.yaml')
         sys.exit(0)
     else:
         rp = Processor(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,9 @@ numpy
 cython
 fabio
 pyFAI
-sphinx
-sphinxcontrib-programoutput
+PyYAML
+# Those are optional build dependencies. It's better to create a separate
+# `requirements-dev.txt` file and install the sphinx dependencies from it prior
+# to the installation.
+# sphinx
+# sphinxcontrib-programoutput

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ __license__ = "MIT"
 
 import sys
 import os
-import platform
 
 from numpy.distutils.misc_util import Configuration
 
@@ -64,7 +63,7 @@ def get_version():
 
 def get_readme():
     dirname = os.path.dirname(os.path.abspath(__file__))
-    with open(os.path.join(dirname, "README.md"), "r") as fp:
+    with open(os.path.join(dirname, "README.md"), "r", encoding='utf-8') as fp:
         long_description = fp.read()
     return long_description
 

--- a/version.py
+++ b/version.py
@@ -66,4 +66,4 @@ hexversion |= version_info[1] * 1 << 16
 hexversion |= version_info[0] * 1 << 24
 
 if __name__ == '__main__':
-    print version
+    print(version)


### PR DESCRIPTION
This PR adds the Python 3+ support (based on https://github.com/tgdane/pygix/compare/master...ronpandolfi:master changes) and adds a missing `LICENSE` file with the MIT license text.

xref https://github.com/tgdane/pygix/issues/2#issuecomment-936918072.